### PR TITLE
Less `&String`!

### DIFF
--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -5,6 +5,7 @@ use error::*;
 use {CgroupPid, ControllIdentifier, Controller, Hierarchy, Resources, Subsystem};
 
 use std::convert::From;
+use std::path::Path;
 
 /// A control group is the central structure to this crate.
 ///
@@ -40,7 +41,7 @@ impl<'b> Cgroup<'b> {
     ///
     /// Note that if the handle goes out of scope and is dropped, the control group is _not_
     /// destroyed.
-    pub fn new(hier: &Hierarchy, path: String) -> Cgroup {
+    pub fn new<P: AsRef<Path>>(hier: &Hierarchy, path: P) -> Cgroup {
         let cg = Cgroup::load(hier, path);
         cg.create();
         cg
@@ -53,12 +54,13 @@ impl<'b> Cgroup<'b> {
     ///
     /// Note that if the handle goes out of scope and is dropped, the control group is _not_
     /// destroyed.
-    pub fn load(hier: &Hierarchy, path: String) -> Cgroup {
+    pub fn load<P: AsRef<Path>>(hier: &Hierarchy, path: P) -> Cgroup {
+        let path = path.as_ref();
         let mut subsystems = hier.subsystems();
-        if path != "" {
+        if path.as_os_str() != "" {
             subsystems = subsystems
                 .into_iter()
-                .map(|x| x.enter(&path))
+                .map(|x| x.enter(path))
                 .collect::<Vec<_>>();
         }
 

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -309,7 +309,7 @@ impl CpuSetController {
     ///
     /// Syntax is a comma separated list of CPUs, with an additional extension that ranges can
     /// be represented via dashes.
-    pub fn set_cpus(&self, cpus: &String) -> Result<()> {
+    pub fn set_cpus(&self, cpus: &str) -> Result<()> {
         self.open_path("cpuset.cpus", true).and_then(|mut file| {
             file.write_all(cpus.as_ref())
                 .map_err(|e| Error::with_cause(WriteFailed, e))
@@ -319,7 +319,7 @@ impl CpuSetController {
     /// Set the memory nodes that the tasks in this control group can use.
     ///
     /// Syntax is the same as with `set_cpus()`.
-    pub fn set_mems(&self, mems: &String) -> Result<()> {
+    pub fn set_mems(&self, mems: &str) -> Result<()> {
         self.open_path("cpuset.mems", true).and_then(|mut file| {
             file.write_all(mems.as_ref())
                 .map_err(|e| Error::with_cause(WriteFailed, e))

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -94,7 +94,7 @@ impl DevicePermissions {
     }
 
     /// Checks whether the string is a valid descriptor of DevicePermissions.
-    pub fn is_valid(s: &String) -> bool {
+    pub fn is_valid(s: &str) -> bool {
         if s == "" {
             return false;
         }
@@ -116,18 +116,18 @@ impl DevicePermissions {
     }
 
     /// Convert a string into DevicePermissions.
-    ///
-    /// NOTE: This function makes no effort in verifying the String.
-    pub fn from_string(s: &String) -> Vec<DevicePermissions> {
+    pub fn from_str(s: &str) -> Result<Vec<DevicePermissions>> {
         let mut v = Vec::new();
         if s == "" {
-            return v;
+            return Ok(v);
         }
         for e in s.chars() {
-            v.push(DevicePermissions::from_char(e).unwrap());
+            let perm = DevicePermissions::from_char(e)
+                .ok_or_else(|| Error::new(ParseError))?;
+            v.push(perm);
         }
 
-        v
+        Ok(v)
     }
 }
 
@@ -285,7 +285,7 @@ impl DevicesController {
                                          acc, ls, devtype, major, minor, &ls[3]);
                                 Err(Error::new(ParseError))
                             } else {
-                                let access = DevicePermissions::from_string(&ls[3]);
+                                let access = DevicePermissions::from_str(&ls[3])?;
                                 let mut acc = acc.unwrap();
                                 acc.push(DeviceResource {
                                     allow: true,

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -94,34 +94,34 @@ impl HugeTlbController {
     }
 
     /// Whether the system supports `hugetlb_size` hugepages.
-    pub fn size_supported(&self, _hugetlb_size: String) -> bool {
+    pub fn size_supported(&self, _hugetlb_size: &str) -> bool {
         // TODO
         true
     }
 
     /// Check how many times has the limit of `hugetlb_size` hugepages been hit.
-    pub fn failcnt(&self, hugetlb_size: &String) -> Result<u64> {
+    pub fn failcnt(&self, hugetlb_size: &str) -> Result<u64> {
         self.open_path(&format!("hugetlb.{}.failcnt", hugetlb_size), false)
             .and_then(read_u64_from)
     }
 
     /// Get the limit (in bytes) of how much memory can be backed by hugepages of a certain size
     /// (`hugetlb_size`).
-    pub fn limit_in_bytes(&self, hugetlb_size: &String) -> Result<u64> {
+    pub fn limit_in_bytes(&self, hugetlb_size: &str) -> Result<u64> {
         self.open_path(&format!("hugetlb.{}.limit_in_bytes", hugetlb_size), false)
             .and_then(read_u64_from)
     }
 
     /// Get the current usage of memory that is backed by hugepages of a certain size
     /// (`hugetlb_size`).
-    pub fn usage_in_bytes(&self, hugetlb_size: &String) -> Result<u64> {
+    pub fn usage_in_bytes(&self, hugetlb_size: &str) -> Result<u64> {
         self.open_path(&format!("hugetlb.{}.usage_in_bytes", hugetlb_size), false)
             .and_then(read_u64_from)
     }
 
     /// Get the maximum observed usage of memory that is backed by hugepages of a certain size
     /// (`hugetlb_size`).
-    pub fn max_usage_in_bytes(&self, hugetlb_size: &String) -> Result<u64> {
+    pub fn max_usage_in_bytes(&self, hugetlb_size: &str) -> Result<u64> {
         self.open_path(
             &format!("hugetlb.{}.max_usage_in_bytes", hugetlb_size),
             false,
@@ -130,7 +130,7 @@ impl HugeTlbController {
 
     /// Set the limit (in bytes) of how much memory can be backed by hugepages of a certain size
     /// (`hugetlb_size`).
-    pub fn set_limit_in_bytes(&self, hugetlb_size: &String, limit: u64) -> Result<()> {
+    pub fn set_limit_in_bytes(&self, hugetlb_size: &str, limit: u64) -> Result<()> {
         self.open_path(&format!("hugetlb.{}.limit_in_bytes", hugetlb_size), false)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate log;
 
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub mod blkio;
 pub mod cgroup;
@@ -491,7 +491,7 @@ impl<'a> From<&'a std::process::Child> for CgroupPid {
 }
 
 impl Subsystem {
-    fn enter(self, path: &String) -> Self {
+    fn enter(self, path: &Path) -> Self {
         match self {
             Subsystem::Pid(cont) => Subsystem::Pid({
                 let mut c = cont.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,9 @@ pub trait Controller {
     #[doc(hidden)]
     fn control_type(&self) -> Controllers;
 
+    /// The file system path to the controller.
+    fn path(&self) -> &Path;
+
     /// Apply a set of resources to the Controller, invoking its internal functions to pass the
     /// kernel the information.
     fn apply(&self, res: &Resources) -> Result<()>;
@@ -191,6 +194,10 @@ pub trait Controller {
 impl<T> Controller for T where T: ControllerInternal {
     fn control_type(&self) -> Controllers {
         ControllerInternal::control_type(self)
+    }
+
+    fn path(&self) -> &Path {
+        self.get_path()
     }
 
     /// Apply a set of resources to the Controller, invoking its internal functions to pass the

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -133,7 +133,7 @@ impl NetPrioController {
     }
 
     /// Set the priority of the network traffic on `eif` to be `prio`.
-    pub fn set_if_prio(&self, eif: &String, prio: u64) -> Result<()> {
+    pub fn set_if_prio(&self, eif: &str, prio: u64) -> Result<()> {
         self.open_path("net_prio.ifpriomap", true)
             .and_then(|mut file| {
                 file.write_all(format!("{} {}", eif, prio).as_ref())

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -86,7 +86,7 @@ impl RdmaController {
     }
 
     /// Set a maximum usage for each RDMA/IB resource.
-    pub fn set_max(&self, max: &String) -> Result<()> {
+    pub fn set_max(&self, max: &str) -> Result<()> {
         self.open_path("rdma.max", true).and_then(|mut file| {
             file.write_all(max.as_ref())
                 .map_err(|e| Error::with_cause(WriteFailed, e))


### PR DESCRIPTION
Went through and replaced all of the `&String` function arguments with either `&str` or `&Path` as appropriate.

I also exposed a new function `Controller::path(&self)`, which I need so I can `chown` the cgroup to a different user.