### PR TITLE
Reorganize error

### DIFF
--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -98,7 +98,9 @@ fn parse_io_service_total(s: String) -> Result<u64> {
         .filter(|x| x.split_whitespace().collect::<Vec<_>>().len() == 2)
         .fold(Err(Error::new(ErrorKind::ParseError)), |_, x| {
             match x.split_whitespace().collect::<Vec<_>>().as_slice() {
-                ["Total", val] => val.parse::<u64>().map_err(|_| Error::new(ErrorKind::ParseError)),
+                ["Total", val] => val
+                    .parse::<u64>()
+                    .map_err(|_| Error::new(ErrorKind::ParseError)),
                 _ => Err(Error::new(ErrorKind::ParseError)),
             }
         })
@@ -327,7 +329,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -337,8 +339,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -586,7 +588,7 @@ impl BlkIoController {
         self.open_path("blkio.leaf_weight", true)
             .and_then(|mut file| {
                 file.write_all(w.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -595,7 +597,7 @@ impl BlkIoController {
         self.open_path("blkio.leaf_weight_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, weight).as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -604,7 +606,7 @@ impl BlkIoController {
         self.open_path("blkio.reset_stats", true)
             .and_then(|mut file| {
                 file.write_all("1".to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -614,7 +616,7 @@ impl BlkIoController {
         self.open_path("blkio.throttle.read_bps_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, bps).to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -624,7 +626,7 @@ impl BlkIoController {
         self.open_path("blkio.throttle.read_iops_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, iops).to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
     /// Throttle the bytes per second rate of write operation affecting the block device
@@ -633,7 +635,7 @@ impl BlkIoController {
         self.open_path("blkio.throttle.write_bps_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, bps).to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -643,7 +645,7 @@ impl BlkIoController {
         self.open_path("blkio.throttle.write_iops_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, iops).to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -651,7 +653,7 @@ impl BlkIoController {
     pub fn set_weight(&self, w: u64) -> Result<()> {
         self.open_path("blkio.weight", true).and_then(|mut file| {
             file.write_all(w.to_string().as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -660,7 +662,7 @@ impl BlkIoController {
         self.open_path("blkio.weight_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, weight).as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 }

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -6,8 +6,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     BlkIoResources, ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem,
@@ -279,7 +279,8 @@ impl ControllerInternal for BlkIoController {
 
             for dev in &res.weight_device {
                 let _ = self.set_weight_for_device(dev.major, dev.minor, dev.weight as u64);
-                let _ = self.set_leaf_weight_for_device(dev.major, dev.minor, dev.leaf_weight as u64);
+                let _ =
+                    self.set_leaf_weight_for_device(dev.major, dev.minor, dev.leaf_weight as u64);
             }
 
             for dev in &res.throttle_read_bps_device {
@@ -334,7 +335,10 @@ fn read_string_from(mut file: File) -> Result<String> {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -588,12 +592,7 @@ impl BlkIoController {
     }
 
     /// Same as `set_leaf_weight()`, but settable per each block device.
-    pub fn set_leaf_weight_for_device(
-        &self,
-        major: u64,
-        minor: u64,
-        weight: u64,
-    ) -> Result<()> {
+    pub fn set_leaf_weight_for_device(&self, major: u64, minor: u64, weight: u64) -> Result<()> {
         self.open_path("blkio.leaf_weight_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, weight).as_ref())
@@ -612,12 +611,7 @@ impl BlkIoController {
 
     /// Throttle the bytes per second rate of read operation affecting the block device
     /// `major:minor` to `bps`.
-    pub fn throttle_read_bps_for_device(
-        &self,
-        major: u64,
-        minor: u64,
-        bps: u64,
-    ) -> Result<()> {
+    pub fn throttle_read_bps_for_device(&self, major: u64, minor: u64, bps: u64) -> Result<()> {
         self.open_path("blkio.throttle.read_bps_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, bps).to_string().as_ref())
@@ -627,12 +621,7 @@ impl BlkIoController {
 
     /// Throttle the I/O operations per second rate of read operation affecting the block device
     /// `major:minor` to `bps`.
-    pub fn throttle_read_iops_for_device(
-        &self,
-        major: u64,
-        minor: u64,
-        iops: u64,
-    ) -> Result<()> {
+    pub fn throttle_read_iops_for_device(&self, major: u64, minor: u64, iops: u64) -> Result<()> {
         self.open_path("blkio.throttle.read_iops_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, iops).to_string().as_ref())
@@ -641,12 +630,7 @@ impl BlkIoController {
     }
     /// Throttle the bytes per second rate of write operation affecting the block device
     /// `major:minor` to `bps`.
-    pub fn throttle_write_bps_for_device(
-        &self,
-        major: u64,
-        minor: u64,
-        bps: u64,
-    ) -> Result<()> {
+    pub fn throttle_write_bps_for_device(&self, major: u64, minor: u64, bps: u64) -> Result<()> {
         self.open_path("blkio.throttle.write_bps_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, bps).to_string().as_ref())
@@ -656,12 +640,7 @@ impl BlkIoController {
 
     /// Throttle the I/O operations per second rate of write operation affecting the block device
     /// `major:minor` to `bps`.
-    pub fn throttle_write_iops_for_device(
-        &self,
-        major: u64,
-        minor: u64,
-        iops: u64,
-    ) -> Result<()> {
+    pub fn throttle_write_iops_for_device(&self, major: u64, minor: u64, iops: u64) -> Result<()> {
         self.open_path("blkio.throttle.write_iops_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, iops).to_string().as_ref())
@@ -671,20 +650,14 @@ impl BlkIoController {
 
     /// Set the weight of the control group's tasks.
     pub fn set_weight(&self, w: u64) -> Result<()> {
-        self.open_path("blkio.weight", true)
-            .and_then(|mut file| {
-                file.write_all(w.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
-            })
+        self.open_path("blkio.weight", true).and_then(|mut file| {
+            file.write_all(w.to_string().as_ref())
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 
     /// Same as `set_weight()`, but settable per each block device.
-    pub fn set_weight_for_device(
-        &self,
-        major: u64,
-        minor: u64,
-        weight: u64,
-    ) -> Result<()> {
+    pub fn set_weight_for_device(&self, major: u64, minor: u64, weight: u64) -> Result<()> {
         self.open_path("blkio.weight_device", true)
             .and_then(|mut file| {
                 file.write_all(format!("{}:{} {}", major, minor, weight).as_ref())
@@ -755,10 +728,7 @@ Total 61823067136
     #[test]
     fn test_parse_io_service_total() {
         let ok = parse_io_service_total(TEST_VALUE.to_string()).unwrap();
-        assert_eq!(
-            ok,
-            61823067136
-        );
+        assert_eq!(ok, 61823067136);
     }
 
     #[test]
@@ -806,10 +776,7 @@ Total 61823067136
             ]
         );
         let err = parse_io_service(TEST_WRONG_VALUE.to_string()).unwrap_err();
-        assert_eq!(
-            err.kind(),
-            &ErrorKind::ParseError,
-        );
+        assert_eq!(err.kind(), &ErrorKind::ParseError,);
     }
 
     #[test]

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -84,7 +84,7 @@ fn parse_io_service(s: String) -> Result<Vec<IoService>> {
         })
         .fold(Ok(Vec::new()), |acc, x| {
             if acc.is_err() || x.is_none() {
-                Err(Error::new(ErrorKind::ParseError))
+                Err(Error::new(ErrorKind::ParseFailed))
             } else {
                 let mut acc = acc.unwrap();
                 acc.push(x.unwrap());
@@ -96,12 +96,12 @@ fn parse_io_service(s: String) -> Result<Vec<IoService>> {
 fn parse_io_service_total(s: String) -> Result<u64> {
     s.lines()
         .filter(|x| x.split_whitespace().collect::<Vec<_>>().len() == 2)
-        .fold(Err(Error::new(ErrorKind::ParseError)), |_, x| {
+        .fold(Err(Error::new(ErrorKind::ParseFailed)), |_, x| {
             match x.split_whitespace().collect::<Vec<_>>().as_slice() {
                 ["Total", val] => val
                     .parse::<u64>()
-                    .map_err(|_| Error::new(ErrorKind::ParseError)),
-                _ => Err(Error::new(ErrorKind::ParseError)),
+                    .map_err(|_| Error::new(ErrorKind::ParseFailed)),
+                _ => Err(Error::new(ErrorKind::ParseFailed)),
             }
         })
 }
@@ -130,11 +130,11 @@ fn parse_blkio_data(s: String) -> Result<Vec<BlkIoData>> {
             });
             Ok(())
         }
-        _ => Err(Error::new(ErrorKind::ParseError)),
+        _ => Err(Error::new(ErrorKind::ParseFailed)),
     });
 
     if err.is_err() {
-        return Err(Error::new(ErrorKind::ParseError));
+        return Err(Error::new(ErrorKind::ParseFailed));
     } else {
         return Ok(res);
     }
@@ -339,7 +339,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseFailed, e)),
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
@@ -777,7 +777,7 @@ Total 61823067136
             ]
         );
         let err = parse_io_service(TEST_WRONG_VALUE.to_string()).unwrap_err();
-        assert_eq!(err.kind(), &ErrorKind::ParseError,);
+        assert_eq!(err.kind(), &ErrorKind::ParseFailed,);
     }
 
     #[test]

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -1,11 +1,10 @@
 //! This module handles cgroup operations. Start here!
 
-use crate::error::*;
-
-use crate::{CgroupPid, ControllIdentifier, Controller, Hierarchy, Resources, Subsystem};
-
 use std::convert::From;
 use std::path::Path;
+
+use crate::error::Result;
+use crate::{CgroupPid, ControllIdentifier, Controller, Hierarchy, Resources, Subsystem};
 
 /// A control group is the central structure to this crate.
 ///

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -24,7 +24,7 @@ pub struct Cgroup<'b> {
     subsystems: Vec<Subsystem>,
 
     /// The hierarchy.
-    hier: &'b Hierarchy,
+    hier: &'b dyn Hierarchy,
 }
 
 impl<'b> Cgroup<'b> {
@@ -41,7 +41,7 @@ impl<'b> Cgroup<'b> {
     ///
     /// Note that if the handle goes out of scope and is dropped, the control group is _not_
     /// destroyed.
-    pub fn new<P: AsRef<Path>>(hier: &Hierarchy, path: P) -> Cgroup {
+    pub fn new<P: AsRef<Path>>(hier: &dyn Hierarchy, path: P) -> Cgroup<'_> {
         let cg = Cgroup::load(hier, path);
         cg.create();
         cg
@@ -54,7 +54,7 @@ impl<'b> Cgroup<'b> {
     ///
     /// Note that if the handle goes out of scope and is dropped, the control group is _not_
     /// destroyed.
-    pub fn load<P: AsRef<Path>>(hier: &Hierarchy, path: P) -> Cgroup {
+    pub fn load<P: AsRef<Path>>(hier: &dyn Hierarchy, path: P) -> Cgroup<'_> {
         let path = path.as_ref();
         let mut subsystems = hier.subsystems();
         if path.as_os_str() != "" {

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -53,7 +53,6 @@
 //!          .done()
 //!      .build();
 //! ```
-use crate::error::*;
 
 use crate::{
     pid, BlkIoDeviceResource, BlkIoDeviceThrottleResource, Cgroup, DeviceResource, Hierarchy,
@@ -74,7 +73,7 @@ macro_rules! gen_setter {
 /// A control group builder instance
 pub struct CgroupBuilder<'a> {
     name: String,
-    hierarchy: &'a Hierarchy,
+    hierarchy: &'a dyn Hierarchy,
     /// Internal, unsupported field: use the associated builders instead.
     resources: Resources,
 }
@@ -83,7 +82,7 @@ impl<'a> CgroupBuilder<'a> {
     /// Start building a control group with the supplied hierarchy and name pair.
     ///
     /// Note that this does not actually create the control group until `build()` is called.
-    pub fn new(name: &'a str, hierarchy: &'a Hierarchy) -> CgroupBuilder<'a> {
+    pub fn new(name: &'a str, hierarchy: &'a dyn Hierarchy) -> CgroupBuilder<'a> {
         CgroupBuilder {
             name: name.to_owned(),
             hierarchy: hierarchy,

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -1,4 +1,5 @@
 //! This module allows the user to create a control group using the Builder pattern.
+//!
 //! # Example
 //!
 //! The following example demonstrates how the control group builder looks like.  The user

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -55,7 +55,10 @@
 //! ```
 use crate::error::*;
 
-use crate::{pid, BlkIoDeviceResource, BlkIoDeviceThrottleResource,  Cgroup, DeviceResource, Hierarchy, HugePageResource, NetworkPriority, Resources};
+use crate::{
+    pid, BlkIoDeviceResource, BlkIoDeviceThrottleResource, Cgroup, DeviceResource, Hierarchy,
+    HugePageResource, NetworkPriority, Resources,
+};
 
 macro_rules! gen_setter {
     ($res:ident, $cont:ident, $func:ident, $name:ident, $ty:ty) => {
@@ -90,46 +93,34 @@ impl<'a> CgroupBuilder<'a> {
 
     /// Builds the memory resources of the control group.
     pub fn memory(self) -> MemoryResourceBuilder<'a> {
-        MemoryResourceBuilder {
-            cgroup: self,
-        }
+        MemoryResourceBuilder { cgroup: self }
     }
 
     /// Builds the pid resources of the control group.
     pub fn pid(self) -> PidResourceBuilder<'a> {
-        PidResourceBuilder {
-            cgroup: self,
-        }
+        PidResourceBuilder { cgroup: self }
     }
 
     /// Builds the cpu resources of the control group.
     pub fn cpu(self) -> CpuResourceBuilder<'a> {
-        CpuResourceBuilder {
-            cgroup: self,
-        }
+        CpuResourceBuilder { cgroup: self }
     }
 
     /// Builds the devices resources of the control group, disallowing or
     /// allowing access to certain devices in the system.
     pub fn devices(self) -> DeviceResourceBuilder<'a> {
-        DeviceResourceBuilder {
-            cgroup: self,
-        }
+        DeviceResourceBuilder { cgroup: self }
     }
 
     /// Builds the network resources of the control group, setting class id, or
     /// various priorities on networking interfaces.
     pub fn network(self) -> NetworkResourceBuilder<'a> {
-        NetworkResourceBuilder {
-            cgroup: self,
-        }
+        NetworkResourceBuilder { cgroup: self }
     }
 
     /// Builds the hugepage/hugetlb resources available to the control group.
     pub fn hugepages(self) -> HugepagesResourceBuilder<'a> {
-        HugepagesResourceBuilder {
-            cgroup: self,
-        }
+        HugepagesResourceBuilder { cgroup: self }
     }
 
     /// Builds the block I/O resources available for the control group.
@@ -154,12 +145,35 @@ pub struct MemoryResourceBuilder<'a> {
 }
 
 impl<'a> MemoryResourceBuilder<'a> {
-
-    gen_setter!(memory, MemController, set_kmem_limit, kernel_memory_limit, u64);
+    gen_setter!(
+        memory,
+        MemController,
+        set_kmem_limit,
+        kernel_memory_limit,
+        u64
+    );
     gen_setter!(memory, MemController, set_limit, memory_hard_limit, u64);
-    gen_setter!(memory, MemController, set_soft_limit, memory_soft_limit, u64);
-    gen_setter!(memory, MemController, set_tcp_limit, kernel_tcp_memory_limit, u64);
-    gen_setter!(memory, MemController, set_memswap_limit, memory_swap_limit, u64);
+    gen_setter!(
+        memory,
+        MemController,
+        set_soft_limit,
+        memory_soft_limit,
+        u64
+    );
+    gen_setter!(
+        memory,
+        MemController,
+        set_tcp_limit,
+        kernel_tcp_memory_limit,
+        u64
+    );
+    gen_setter!(
+        memory,
+        MemController,
+        set_memswap_limit,
+        memory_swap_limit,
+        u64
+    );
     gen_setter!(memory, MemController, set_swappiness, swappiness, u64);
 
     /// Finish the construction of the memory resources of a control group.
@@ -174,8 +188,13 @@ pub struct PidResourceBuilder<'a> {
 }
 
 impl<'a> PidResourceBuilder<'a> {
-
-    gen_setter!(pid, PidController, set_pid_max, maximum_number_of_processes, pid::PidMax);
+    gen_setter!(
+        pid,
+        PidController,
+        set_pid_max,
+        maximum_number_of_processes,
+        pid::PidMax
+    );
 
     /// Finish the construction of the pid resources of a control group.
     pub fn done(self) -> CgroupBuilder<'a> {
@@ -189,7 +208,6 @@ pub struct CpuResourceBuilder<'a> {
 }
 
 impl<'a> CpuResourceBuilder<'a> {
-
     gen_setter!(cpu, CpuSetController, set_cpus, cpus, String);
     gen_setter!(cpu, CpuSetController, set_mems, mems, String);
     gen_setter!(cpu, CpuController, set_shares, shares, u64);
@@ -210,22 +228,22 @@ pub struct DeviceResourceBuilder<'a> {
 }
 
 impl<'a> DeviceResourceBuilder<'a> {
-
     /// Restrict (or allow) a device to the tasks inside the control group.
-    pub fn device(mut self,
-                  major: i64,
-                  minor: i64,
-                  devtype: crate::devices::DeviceType,
-                  allow: bool,
-                  access: Vec<crate::devices::DevicePermissions>)
-            -> DeviceResourceBuilder<'a> {
+    pub fn device(
+        mut self,
+        major: i64,
+        minor: i64,
+        devtype: crate::devices::DeviceType,
+        allow: bool,
+        access: Vec<crate::devices::DevicePermissions>,
+    ) -> DeviceResourceBuilder<'a> {
         self.cgroup.resources.devices.update_values = true;
         self.cgroup.resources.devices.devices.push(DeviceResource {
             major,
             minor,
             devtype,
             allow,
-            access
+            access,
         });
         self
     }
@@ -242,18 +260,17 @@ pub struct NetworkResourceBuilder<'a> {
 }
 
 impl<'a> NetworkResourceBuilder<'a> {
-
     gen_setter!(network, NetclsController, set_class, class_id, u64);
 
     /// Set the priority of the tasks when operating on a networking device defined by `name` to be
     /// `priority`.
-    pub fn priority(mut self, name: String, priority: u64)
-        -> NetworkResourceBuilder<'a> {
+    pub fn priority(mut self, name: String, priority: u64) -> NetworkResourceBuilder<'a> {
         self.cgroup.resources.network.update_values = true;
-        self.cgroup.resources.network.priorities.push(NetworkPriority {
-            name,
-            priority,
-        });
+        self.cgroup
+            .resources
+            .network
+            .priorities
+            .push(NetworkPriority { name, priority });
         self
     }
 
@@ -269,15 +286,14 @@ pub struct HugepagesResourceBuilder<'a> {
 }
 
 impl<'a> HugepagesResourceBuilder<'a> {
-
     /// Limit the usage of certain hugepages (determined by `size`) to be at most `limit` bytes.
-    pub fn limit(mut self, size: String, limit: u64)
-        -> HugepagesResourceBuilder<'a> {
+    pub fn limit(mut self, size: String, limit: u64) -> HugepagesResourceBuilder<'a> {
         self.cgroup.resources.hugepages.update_values = true;
-        self.cgroup.resources.hugepages.limits.push(HugePageResource {
-            size,
-            limit,
-        });
+        self.cgroup
+            .resources
+            .hugepages
+            .limits
+            .push(HugePageResource { size, limit });
         self
     }
 
@@ -294,24 +310,28 @@ pub struct BlkIoResourcesBuilder<'a> {
 }
 
 impl<'a> BlkIoResourcesBuilder<'a> {
-
     gen_setter!(blkio, BlkIoController, set_weight, weight, u16);
     gen_setter!(blkio, BlkIoController, set_leaf_weight, leaf_weight, u16);
 
     /// Set the weight of a certain device.
-    pub fn weight_device(mut self,
-                         major: u64,
-                         minor: u64,
-                         weight: u16,
-                         leaf_weight: u16)
-        -> BlkIoResourcesBuilder<'a> {
+    pub fn weight_device(
+        mut self,
+        major: u64,
+        minor: u64,
+        weight: u16,
+        leaf_weight: u16,
+    ) -> BlkIoResourcesBuilder<'a> {
         self.cgroup.resources.blkio.update_values = true;
-        self.cgroup.resources.blkio.weight_device.push(BlkIoDeviceResource {
-            major,
-            minor,
-            weight,
-            leaf_weight,
-        });
+        self.cgroup
+            .resources
+            .blkio
+            .weight_device
+            .push(BlkIoDeviceResource {
+                major,
+                minor,
+                weight,
+                leaf_weight,
+            });
         self
     }
 
@@ -328,35 +348,41 @@ impl<'a> BlkIoResourcesBuilder<'a> {
     }
 
     /// Limit the read rate of the current metric for a certain device.
-    pub fn read(mut self, major: u64, minor: u64, rate: u64)
-        -> BlkIoResourcesBuilder<'a> {
+    pub fn read(mut self, major: u64, minor: u64, rate: u64) -> BlkIoResourcesBuilder<'a> {
         self.cgroup.resources.blkio.update_values = true;
-        let throttle = BlkIoDeviceThrottleResource {
-            major,
-            minor,
-            rate,
-        };
+        let throttle = BlkIoDeviceThrottleResource { major, minor, rate };
         if self.throttling_iops {
-            self.cgroup.resources.blkio.throttle_read_iops_device.push(throttle);
+            self.cgroup
+                .resources
+                .blkio
+                .throttle_read_iops_device
+                .push(throttle);
         } else {
-            self.cgroup.resources.blkio.throttle_read_bps_device.push(throttle);
+            self.cgroup
+                .resources
+                .blkio
+                .throttle_read_bps_device
+                .push(throttle);
         }
         self
     }
 
     /// Limit the write rate of the current metric for a certain device.
-    pub fn write(mut self, major: u64, minor: u64, rate: u64)
-        -> BlkIoResourcesBuilder<'a> {
+    pub fn write(mut self, major: u64, minor: u64, rate: u64) -> BlkIoResourcesBuilder<'a> {
         self.cgroup.resources.blkio.update_values = true;
-        let throttle = BlkIoDeviceThrottleResource {
-            major,
-            minor,
-            rate,
-        };
+        let throttle = BlkIoDeviceThrottleResource { major, minor, rate };
         if self.throttling_iops {
-            self.cgroup.resources.blkio.throttle_write_iops_device.push(throttle);
+            self.cgroup
+                .resources
+                .blkio
+                .throttle_write_iops_device
+                .push(throttle);
         } else {
-            self.cgroup.resources.blkio.throttle_write_bps_device.push(throttle);
+            self.cgroup
+                .resources
+                .blkio
+                .throttle_write_bps_device
+                .push(throttle);
         }
         self
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -3,13 +3,12 @@
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/scheduler/sched-design-CFS.txt](https://www.kernel.org/doc/Documentation/scheduler/sched-design-CFS.txt)
 //!  paragraph 7 ("GROUP SCHEDULER EXTENSIONS TO CFS").
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, CpuResources, Resources, Subsystem,
 };
@@ -105,8 +104,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -131,7 +130,7 @@ impl CpuController {
                     let res = file.read_to_string(&mut s);
                     match res {
                         Ok(_) => Ok(s),
-                        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+                        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
                     }
                 })
                 .unwrap_or("".to_string()),
@@ -147,7 +146,7 @@ impl CpuController {
     pub fn set_shares(&self, shares: u64) -> Result<()> {
         self.open_path("cpu.shares", true).and_then(|mut file| {
             file.write_all(shares.to_string().as_ref())
-                .map_err(|e| Error::with_cause(WriteFailed, e))
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -163,7 +162,7 @@ impl CpuController {
         self.open_path("cpu.cfs_period_us", true)
             .and_then(|mut file| {
                 file.write_all(us.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -180,7 +179,7 @@ impl CpuController {
         self.open_path("cpu.cfs_quota_us", true)
             .and_then(|mut file| {
                 file.write_all(us.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -58,17 +58,17 @@ impl ControllerInternal for CpuController {
             // apply pid_max
             let _ = self.set_shares(res.shares);
             if self.shares()? != res.shares as u64 {
-                return Err(Error::new(ErrorKind::Other));
+                return Err(Error::new(ErrorKind::ApplyFailed));
             }
 
             let _ = self.set_cfs_period(res.period);
             if self.cfs_period()? != res.period as u64 {
-                return Err(Error::new(ErrorKind::Other));
+                return Err(Error::new(ErrorKind::ApplyFailed));
             }
 
             let _ = self.set_cfs_quota(res.quota as u64);
             if self.cfs_quota()? != res.quota as u64 {
-                return Err(Error::new(ErrorKind::Other));
+                return Err(Error::new(ErrorKind::ApplyFailed));
             }
 
             // TODO: rt properties (CONFIG_RT_GROUP_SCHED) are not yet supported

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -7,8 +7,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, CpuResources, Resources, Subsystem,
@@ -102,7 +102,10 @@ impl<'a> From<&'a Subsystem> for &'a CpuController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -130,7 +133,8 @@ impl CpuController {
                         Ok(_) => Ok(s),
                         Err(e) => Err(Error::with_cause(ReadFailed, e)),
                     }
-                }).unwrap_or("".to_string()),
+                })
+                .unwrap_or("".to_string()),
         }
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -104,8 +104,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -130,7 +130,7 @@ impl CpuController {
                     let res = file.read_to_string(&mut s);
                     match res {
                         Ok(_) => Ok(s),
-                        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+                        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
                     }
                 })
                 .unwrap_or("".to_string()),
@@ -146,7 +146,7 @@ impl CpuController {
     pub fn set_shares(&self, shares: u64) -> Result<()> {
         self.open_path("cpu.shares", true).and_then(|mut file| {
             file.write_all(shares.to_string().as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -162,7 +162,7 @@ impl CpuController {
         self.open_path("cpu.cfs_period_us", true)
             .and_then(|mut file| {
                 file.write_all(us.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -179,7 +179,7 @@ impl CpuController {
         self.open_path("cpu.cfs_quota_us", true)
             .and_then(|mut file| {
                 file.write_all(us.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -104,7 +104,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseFailed, e)),
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -96,9 +96,9 @@ fn read_u64_from(mut file: File) -> Result<u64> {
     match res {
         Ok(_) => match string.trim().parse() {
             Ok(e) => Ok(e),
-            Err(e) => Err(Error::with_cause(ErrorKind::ParseError, e)),
+            Err(e) => Err(Error::with_source(ErrorKind::ParseError, e)),
         },
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -106,7 +106,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -163,7 +163,7 @@ impl CpuAcctController {
     pub fn reset(&self) -> Result<()> {
         self.open_path("cpuacct.usage", true).and_then(|mut file| {
             file.write_all(b"0")
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 }

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -96,7 +96,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
     match res {
         Ok(_) => match string.trim().parse() {
             Ok(e) => Ok(e),
-            Err(e) => Err(Error::with_source(ErrorKind::ParseError, e)),
+            Err(e) => Err(Error::with_source(ErrorKind::ParseFailed, e)),
         },
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -2,13 +2,12 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/cpuacct.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt)
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
 /// A controller that allows controlling the `cpuacct` subsystem of a Cgroup.
@@ -97,9 +96,9 @@ fn read_u64_from(mut file: File) -> Result<u64> {
     match res {
         Ok(_) => match string.trim().parse() {
             Ok(e) => Ok(e),
-            Err(e) => Err(Error::with_cause(ParseError, e)),
+            Err(e) => Err(Error::with_cause(ErrorKind::ParseError, e)),
         },
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -107,7 +106,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -164,7 +163,7 @@ impl CpuAcctController {
     pub fn reset(&self) -> Result<()> {
         self.open_path("cpuacct.usage", true).and_then(|mut file| {
             file.write_all(b"0")
-                .map_err(|e| Error::with_cause(WriteFailed, e))
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })
     }
 }

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -6,8 +6,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
@@ -162,7 +162,9 @@ impl CpuAcctController {
 
     /// Reset the statistics the kernel has gathered about the control group.
     pub fn reset(&self) -> Result<()> {
-        self.open_path("cpuacct.usage", true)
-            .and_then(|mut file| file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e)))
+        self.open_path("cpuacct.usage", true).and_then(|mut file| {
+            file.write_all(b"0")
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 }

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -129,7 +129,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -139,8 +139,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -288,10 +288,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -303,10 +303,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -318,7 +318,7 @@ impl CpuSetController {
     pub fn set_cpus(&self, cpus: &str) -> Result<()> {
         self.open_path("cpuset.cpus", true).and_then(|mut file| {
             file.write_all(cpus.as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -328,7 +328,7 @@ impl CpuSetController {
     pub fn set_mems(&self, mems: &str) -> Result<()> {
         self.open_path("cpuset.mems", true).and_then(|mut file| {
             file.write_all(mems.as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -342,10 +342,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -357,10 +357,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -372,7 +372,7 @@ impl CpuSetController {
         self.open_path("cpuset.sched_relax_domain_level", true)
             .and_then(|mut file| {
                 file.write_all(i.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -383,10 +383,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -398,10 +398,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -413,10 +413,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -434,10 +434,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                        .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
                 }
             })
     }

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -6,8 +6,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, CpuResources, Resources, Subsystem,
@@ -137,7 +137,10 @@ fn read_string_from(mut file: File) -> Result<String> {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -285,9 +288,11 @@ impl CpuSetController {
         self.open_path("cpuset.cpu_exclusive", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -298,9 +303,11 @@ impl CpuSetController {
         self.open_path("cpuset.mem_exclusive", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -335,9 +342,11 @@ impl CpuSetController {
         self.open_path("cpuset.mem_hardwall", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -348,9 +357,11 @@ impl CpuSetController {
         self.open_path("cpuset.sched_load_balance", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -372,9 +383,11 @@ impl CpuSetController {
         self.open_path("cpuset.memory_migrate", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -385,9 +398,11 @@ impl CpuSetController {
         self.open_path("cpuset.memory_spread_page", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -398,9 +413,11 @@ impl CpuSetController {
         self.open_path("cpuset.memory_spread_slab", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -417,9 +434,11 @@ impl CpuSetController {
         self.open_path("cpuset.memory_pressure_enabled", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -2,13 +2,12 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/cpusets.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt)
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, CpuResources, Resources, Subsystem,
 };
@@ -130,7 +129,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -140,8 +139,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -161,19 +160,19 @@ fn parse_range(s: String) -> Result<Vec<(u64, u64)>> {
             // this is a true range
             let dash_split = sp.split("-").collect::<Vec<_>>();
             if dash_split.len() != 2 {
-                return Err(Error::new(ParseError));
+                return Err(Error::new(ErrorKind::ParseError));
             }
             let first = dash_split[0].parse::<u64>();
             let second = dash_split[1].parse::<u64>();
             if first.is_err() || second.is_err() {
-                return Err(Error::new(ParseError));
+                return Err(Error::new(ErrorKind::ParseError));
             }
             fin.push((first.unwrap(), second.unwrap()));
         } else {
             // this is just a single number
             let num = sp.parse::<u64>();
             if num.is_err() {
-                return Err(Error::new(ParseError));
+                return Err(Error::new(ErrorKind::ParseError));
             }
             fin.push((num.clone().unwrap(), num.clone().unwrap()));
         }
@@ -289,10 +288,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -304,10 +303,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -319,7 +318,7 @@ impl CpuSetController {
     pub fn set_cpus(&self, cpus: &str) -> Result<()> {
         self.open_path("cpuset.cpus", true).and_then(|mut file| {
             file.write_all(cpus.as_ref())
-                .map_err(|e| Error::with_cause(WriteFailed, e))
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -329,7 +328,7 @@ impl CpuSetController {
     pub fn set_mems(&self, mems: &str) -> Result<()> {
         self.open_path("cpuset.mems", true).and_then(|mut file| {
             file.write_all(mems.as_ref())
-                .map_err(|e| Error::with_cause(WriteFailed, e))
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -343,10 +342,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -358,10 +357,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -373,7 +372,7 @@ impl CpuSetController {
         self.open_path("cpuset.sched_relax_domain_level", true)
             .and_then(|mut file| {
                 file.write_all(i.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -384,10 +383,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -399,10 +398,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -414,10 +413,10 @@ impl CpuSetController {
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 }
             })
     }
@@ -429,16 +428,16 @@ impl CpuSetController {
     /// control group.
     pub fn set_enable_memory_pressure(&self, b: bool) -> Result<()> {
         if !self.path_exists("cpuset.memory_pressure_enabled") {
-            return Err(Error::new(InvalidOperation));
+            return Err(Error::new(ErrorKind::InvalidOperation));
         }
         self.open_path("cpuset.memory_pressure_enabled", true)
             .and_then(|mut file| {
                 if b {
                     file.write_all(b"1")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 } else {
                     file.write_all(b"0")
-                        .map_err(|e| Error::with_cause(WriteFailed, e))
+                        .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
                 }
             })
     }

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -139,7 +139,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseFailed, e)),
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
@@ -160,19 +160,19 @@ fn parse_range(s: String) -> Result<Vec<(u64, u64)>> {
             // this is a true range
             let dash_split = sp.split("-").collect::<Vec<_>>();
             if dash_split.len() != 2 {
-                return Err(Error::new(ErrorKind::ParseError));
+                return Err(Error::new(ErrorKind::ParseFailed));
             }
             let first = dash_split[0].parse::<u64>();
             let second = dash_split[1].parse::<u64>();
             if first.is_err() || second.is_err() {
-                return Err(Error::new(ErrorKind::ParseError));
+                return Err(Error::new(ErrorKind::ParseFailed));
             }
             fin.push((first.unwrap(), second.unwrap()));
         } else {
             // this is just a single number
             let num = sp.parse::<u64>();
             if num.is_err() {
-                return Err(Error::new(ErrorKind::ParseError));
+                return Err(Error::new(ErrorKind::ParseFailed));
             }
             fin.push((num.clone().unwrap(), num.clone().unwrap()));
         }

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 
 use log::*;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, DeviceResource, DeviceResources,
@@ -124,8 +124,7 @@ impl DevicePermissions {
             return Ok(v);
         }
         for e in s.chars() {
-            let perm = DevicePermissions::from_char(e)
-                .ok_or_else(|| Error::new(ParseError))?;
+            let perm = DevicePermissions::from_char(e).ok_or_else(|| Error::new(ParseError))?;
             v.push(perm);
         }
 

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -121,8 +121,8 @@ impl DevicePermissions {
             return Ok(v);
         }
         for e in s.chars() {
-            let perm =
-                DevicePermissions::from_char(e).ok_or_else(|| Error::new(ErrorKind::ParseError))?;
+            let perm = DevicePermissions::from_char(e)
+                .ok_or_else(|| Error::new(ErrorKind::ParseFailed))?;
             v.push(perm);
         }
 
@@ -268,7 +268,7 @@ impl DevicesController {
                         let ls = line.to_string().split(|c| c == ' ' || c == ':').map(|x| x.to_string()).collect::<Vec<String>>();
                         if acc.is_err() || ls.len() != 4 {
                             log::error!("allowed_devices: acc: {:?}, ls: {:?}", acc, ls);
-                            Err(Error::new(ErrorKind::ParseError))
+                            Err(Error::new(ErrorKind::ParseFailed))
                         } else {
                             let devtype = DeviceType::from_char(ls[0].chars().nth(0));
                             let mut major = ls[1].parse::<i64>();
@@ -282,7 +282,7 @@ impl DevicesController {
                             if devtype.is_none() || major.is_err() || minor.is_err() || !DevicePermissions::is_valid(&ls[3]) {
                                 log::error!("allowed_devices: acc: {:?}, ls: {:?}, devtype: {:?}, major {:?} minor {:?} ls3 {:?}",
                                          acc, ls, devtype, major, minor, &ls[3]);
-                                Err(Error::new(ErrorKind::ParseError))
+                                Err(Error::new(ErrorKind::ParseFailed))
                             } else {
                                 let access = DevicePermissions::from_str(&ls[3])?;
                                 let mut acc = acc.unwrap();

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -121,7 +121,8 @@ impl DevicePermissions {
             return Ok(v);
         }
         for e in s.chars() {
-            let perm = DevicePermissions::from_char(e).ok_or_else(|| Error::new(ErrorKind::ParseError))?;
+            let perm =
+                DevicePermissions::from_char(e).ok_or_else(|| Error::new(ErrorKind::ParseError))?;
             v.push(perm);
         }
 
@@ -220,7 +221,7 @@ impl DevicesController {
         let final_str = format!("{} {}:{} {}", devtype.to_char(), major, minor, perms);
         self.open_path("devices.allow", true).and_then(|mut file| {
             file.write_all(final_str.as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -252,7 +253,7 @@ impl DevicesController {
         let final_str = format!("{} {}:{} {}", devtype.to_char(), major, minor, perms);
         self.open_path("devices.deny", true).and_then(|mut file| {
             file.write_all(final_str.as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -297,7 +298,7 @@ impl DevicesController {
                         }
                     })
                 },
-                Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+                Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
             }
         })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,10 +63,7 @@ impl StdError for Error {
 
 impl Error {
     pub(crate) fn new(kind: ErrorKind) -> Self {
-        Self {
-            kind,
-            cause: None,
-        }
+        Self { kind, cause: None }
     }
 
     pub(crate) fn with_cause<E>(kind: ErrorKind, cause: E) -> Self

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,16 +4,15 @@ use std::fmt;
 /// The different types of errors that can occur while manipulating control groups.
 #[derive(Debug, Eq, PartialEq)]
 pub enum ErrorKind {
-    /// An error occured while writing to a control group file.
-    WriteFailed,
-
-    /// An error occured while trying to read from a control group file.
+    /// Failed to read from a cgroup file.
     ReadFailed,
 
-    /// An error occured while trying to parse a value from a control group file.
-    ///
-    /// In the future, there will be some information attached to this field.
-    ParseError,
+    /// Failed to parse a string in a cgroup file into a value.
+    /// In the future, there will be some information attached to this variant.
+    ParseFailed,
+
+    /// Failed to write to a cgroup file.
+    WriteFailed,
 
     /// You tried to do something invalid.
     ///
@@ -44,7 +43,7 @@ impl fmt::Display for Error {
         let msg = match self.kind {
             ErrorKind::WriteFailed => "unable to write to a control group file",
             ErrorKind::ReadFailed => "unable to read a control group file",
-            ErrorKind::ParseError => "unable to parse control group file",
+            ErrorKind::ParseFailed => "unable to parse control group file",
             ErrorKind::InvalidOperation => "the requested operation is invalid",
             ErrorKind::InvalidPath => "the given path is invalid",
             ErrorKind::Other => "an unknown error",

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,11 +34,11 @@ pub enum ErrorKind {
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
-    cause: Option<Box<StdError + Send>>,
+    cause: Option<Box<dyn StdError + Send>>,
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self.kind {
             ErrorKind::WriteFailed => "unable to write to a control group file",
             ErrorKind::ReadFailed => "unable to read a control group file",
@@ -53,7 +53,7 @@ impl fmt::Display for Error {
 }
 
 impl StdError for Error {
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match self.cause {
             Some(ref x) => Some(&**x),
             None => None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 use std::error::Error as StdError;
 use std::fmt;
 
-/// The different types of errors that can occur while manipulating control groups.
-#[derive(Debug, Eq, PartialEq)]
+/// The kinds of errors that can occur while operating on cgroups.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ErrorKind {
     /// Failed to read from a cgroup file.
     ReadFailed,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,17 @@
 use std::error::Error as StdError;
 use std::fmt;
 
+/// The result type returned from this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// The error type that can be returned from this crate, in the `Result::Err` variant.
+/// The lower-level cause of this error can be obtained from the `source` method.
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    source: Option<Box<dyn StdError + Send + 'static>>,
+}
+
 /// The kinds of errors that can occur while operating on cgroups.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ErrorKind {
@@ -28,14 +39,6 @@ pub enum ErrorKind {
     /// This could be caused by trying to escape the cgroup filesystem via a string of `..`.
     /// This crate checks against this and operations will fail with this error.
     InvalidPath,
-}
-
-/// The error type that can be returned from this crate, in the `Result::Err` variant.
-/// The lower-level cause of this error can be obtained from the `source` method.
-#[derive(Debug)]
-pub struct Error {
-    kind: ErrorKind,
-    source: Option<Box<dyn StdError + Send + 'static>>,
 }
 
 impl fmt::Display for Error {
@@ -81,5 +84,3 @@ impl Error {
         self.kind
     }
 }
-
-pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,4 +81,4 @@ impl Error {
     }
 }
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,20 +14,20 @@ pub enum ErrorKind {
     /// Failed to write to a cgroup file.
     WriteFailed,
 
+    /// Failed to apply a value to a subsystem.
+    ApplyFailed,
+
     /// You tried to do something invalid.
     ///
-    /// This could be because you tried to set a value in a control group that is not a root
-    /// control group. Or, when using unified hierarchy, you tried to add a task in a leaf node.
+    /// This could be because you tried to set a value in a cgroup that is not a root
+    /// cgroup. Or, when using unified hierarchy, you tried to add a task in a non-leaf node.
     InvalidOperation,
 
-    /// The path of the control group was invalid.
+    /// The path of the cgroup was invalid.
     ///
-    /// This could be caused by trying to escape the control group filesystem via a string of "..".
+    /// This could be caused by trying to escape the cgroup filesystem via a string of `..`.
     /// This crate checks against this and operations will fail with this error.
     InvalidPath,
-
-    /// An unknown error has occured.
-    Other,
 }
 
 /// The error type that can be returned from this crate, in the `Result::Err` variant.
@@ -41,14 +41,13 @@ pub struct Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self.kind {
-            ErrorKind::WriteFailed => "unable to write to a control group file",
-            ErrorKind::ReadFailed => "unable to read a control group file",
-            ErrorKind::ParseFailed => "unable to parse control group file",
+            ErrorKind::ReadFailed => "unable to read a cgroup file",
+            ErrorKind::ParseFailed => "unable to parse a string in a cgroup file",
+            ErrorKind::WriteFailed => "unable to write to a cgroup file",
+            ErrorKind::ApplyFailed => "unable to apply a value to a subsystem (controller)",
             ErrorKind::InvalidOperation => "the requested operation is invalid",
             ErrorKind::InvalidPath => "the given path is invalid",
-            ErrorKind::Other => "an unknown error",
         };
-
         write!(f, "{}", msg)
     }
 }
@@ -77,8 +76,9 @@ impl Error {
         }
     }
 
-    pub fn kind(&self) -> &ErrorKind {
-        &self.kind
+    /// Returns the kind of this error.
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
     }
 }
 

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -87,7 +87,7 @@ impl FreezerController {
     pub fn freeze(&self) -> Result<()> {
         self.open_path("freezer.state", true).and_then(|mut file| {
             file.write_all("FROZEN".to_string().as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -95,7 +95,7 @@ impl FreezerController {
     pub fn thaw(&self) -> Result<()> {
         self.open_path("freezer.state", true).and_then(|mut file| {
             file.write_all("THAWED".to_string().as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -111,7 +111,7 @@ impl FreezerController {
                     "FREEZING" => Ok(FreezerState::Freezing),
                     _ => Err(Error::new(ErrorKind::ParseError)),
                 },
-                Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+                Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
             }
         })
     }

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -109,7 +109,7 @@ impl FreezerController {
                     "FROZEN" => Ok(FreezerState::Frozen),
                     "THAWED" => Ok(FreezerState::Thawed),
                     "FREEZING" => Ok(FreezerState::Freezing),
-                    _ => Err(Error::new(ErrorKind::ParseError)),
+                    _ => Err(Error::new(ErrorKind::ParseFailed)),
                 },
                 Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
             }

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -5,8 +5,8 @@
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -2,12 +2,11 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/freezer-subsystem.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
+
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
 /// A controller that allows controlling the `freezer` subsystem of a Cgroup.
@@ -88,7 +87,7 @@ impl FreezerController {
     pub fn freeze(&self) -> Result<()> {
         self.open_path("freezer.state", true).and_then(|mut file| {
             file.write_all("FROZEN".to_string().as_ref())
-                .map_err(|e| Error::with_cause(WriteFailed, e))
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -96,7 +95,7 @@ impl FreezerController {
     pub fn thaw(&self) -> Result<()> {
         self.open_path("freezer.state", true).and_then(|mut file| {
             file.write_all("THAWED".to_string().as_ref())
-                .map_err(|e| Error::with_cause(WriteFailed, e))
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -110,9 +109,9 @@ impl FreezerController {
                     "FROZEN" => Ok(FreezerState::Frozen),
                     "THAWED" => Ok(FreezerState::Thawed),
                     "FREEZING" => Ok(FreezerState::Freezing),
-                    _ => Err(Error::new(ParseError)),
+                    _ => Err(Error::new(ErrorKind::ParseError)),
                 },
-                Err(e) => Err(Error::with_cause(ReadFailed, e)),
+                Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
             }
         })
     }

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -4,28 +4,26 @@
 //! the Unified Hierarchy.
 
 use std::fs::File;
-use std::io::BufRead;
-use std::io::BufReader;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
-use log::*;
-
-use crate::blkio::BlkIoController;
-use crate::cpu::CpuController;
-use crate::cpuacct::CpuAcctController;
-use crate::cpuset::CpuSetController;
-use crate::devices::DevicesController;
-use crate::freezer::FreezerController;
-use crate::hugetlb::HugeTlbController;
-use crate::memory::MemController;
-use crate::net_cls::NetClsController;
-use crate::net_prio::NetPrioController;
-use crate::perf_event::PerfEventController;
-use crate::pid::PidController;
-use crate::rdma::RdmaController;
-use crate::{Controllers, Hierarchy, Subsystem};
-
-use crate::cgroup::Cgroup;
+use crate::{
+    blkio::BlkIoController,
+    cgroup::Cgroup,
+    cpu::CpuController,
+    cpuacct::CpuAcctController,
+    cpuset::CpuSetController,
+    devices::DevicesController,
+    freezer::FreezerController,
+    hugetlb::HugeTlbController,
+    memory::MemController,
+    net_cls::NetClsController,
+    net_prio::NetPrioController,
+    perf_event::PerfEventController,
+    pid::PidController,
+    rdma::RdmaController,
+    {Controllers, Hierarchy, Subsystem},
+};
 
 /// The standard, original cgroup implementation. Often referred to as "cgroupv1".
 pub struct V1 {
@@ -129,7 +127,7 @@ fn find_v1_mount() -> Option<String> {
         let fstype = more_fields[0];
         if fstype == "tmpfs" && more_fields[2].contains("ro") {
             let cgroups_mount = fields.nth(4).unwrap();
-            info!("found cgroups at {:?}", cgroups_mount);
+            log::info!("found cgroups at {:?}", cgroups_mount);
             return Some(cgroups_mount.to_string());
         }
     }

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -78,7 +78,7 @@ impl Hierarchy for V1 {
         subs
     }
 
-    fn root_control_group(&self) -> Cgroup {
+    fn root_control_group(&self) -> Cgroup<'_> {
         Cgroup::load(self, "".to_string())
     }
 
@@ -125,7 +125,7 @@ fn find_v1_mount() -> Option<String> {
         let line = _line.unwrap();
         let mut fields = line.split_whitespace();
         let index = line.find(" - ").unwrap();
-        let mut more_fields = line[index + 3..].split_whitespace().collect::<Vec<_>>();
+        let more_fields = line[index + 3..].split_whitespace().collect::<Vec<_>>();
         let fstype = more_fields[0];
         if fstype == "tmpfs" && more_fields[2].contains("ro") {
             let cgroups_mount = fields.nth(4).unwrap();

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -44,7 +44,7 @@ impl ControllerInternal for HugeTlbController {
             for i in &res.limits {
                 let _ = self.set_limit_in_bytes(&i.size, i.limit);
                 if self.limit_in_bytes(&i.size)? != i.limit {
-                    return Err(Error::new(ErrorKind::Other));
+                    return Err(Error::new(ErrorKind::ApplyFailed));
                 }
             }
         }

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -2,13 +2,12 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/hugetlb.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/hugetlb.txt)
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, HugePageResources, Resources, Subsystem,
 };
@@ -45,7 +44,7 @@ impl ControllerInternal for HugeTlbController {
             for i in &res.limits {
                 let _ = self.set_limit_in_bytes(&i.size, i.limit);
                 if self.limit_in_bytes(&i.size)? != i.limit {
-                    return Err(Error::new(Other));
+                    return Err(Error::new(ErrorKind::Other));
                 }
             }
         }
@@ -79,8 +78,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -137,7 +136,7 @@ impl HugeTlbController {
         self.open_path(&format!("hugetlb.{}.limit_in_bytes", hugetlb_size), true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 }

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -78,8 +78,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -136,7 +136,7 @@ impl HugeTlbController {
         self.open_path(&format!("hugetlb.{}.limit_in_bytes", hugetlb_size), true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 }

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -78,7 +78,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseFailed, e)),
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -6,12 +6,11 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, HugePageResources, Resources,
-    Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, HugePageResources, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `hugetlb` subsystem of a Cgroup.
@@ -77,7 +76,10 @@ impl<'a> From<&'a Subsystem> for &'a HugeTlbController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -125,7 +127,8 @@ impl HugeTlbController {
         self.open_path(
             &format!("hugetlb.{}.max_usage_in_bytes", hugetlb_size),
             false,
-        ).and_then(read_u64_from)
+        )
+        .and_then(read_u64_from)
     }
 
     /// Set the limit (in bytes) of how much memory can be backed by hugepages of a certain size

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 pub mod blkio;
 pub mod cgroup;
+pub mod cgroup_builder;
 pub mod cpu;
 pub mod cpuacct;
 pub mod cpuset;
@@ -20,7 +21,6 @@ pub mod net_prio;
 pub mod perf_event;
 pub mod pid;
 pub mod rdma;
-pub mod cgroup_builder;
 
 use crate::blkio::BlkIoController;
 use crate::cpu::CpuController;
@@ -155,7 +155,6 @@ mod sealed {
 
             std::path::Path::new(p).exists()
         }
-
     }
 }
 
@@ -191,7 +190,10 @@ pub trait Controller {
     fn tasks(&self) -> Vec<CgroupPid>;
 }
 
-impl<T> Controller for T where T: ControllerInternal {
+impl<T> Controller for T
+where
+    T: ControllerInternal,
+{
     fn control_type(&self) -> Controllers {
         ControllerInternal::control_type(self)
     }
@@ -249,7 +251,8 @@ impl<T> Controller for T where T: ControllerInternal {
                     }
                 }
                 Ok(v.into_iter().map(CgroupPid::from).collect())
-            }).unwrap_or(vec![])
+            })
+            .unwrap_or(vec![])
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,15 @@ pub mod pid;
 pub mod rdma;
 
 pub use crate::cgroup::Cgroup;
+pub use crate::error::{Error, ErrorKind, Result};
+
+#[rustfmt::skip]
 use crate::{
     blkio::BlkIoController,
     cpu::CpuController,
     cpuacct::CpuAcctController,
     cpuset::CpuSetController,
     devices::DevicesController,
-    error::{Error, ErrorKind, Result},
     freezer::FreezerController,
     hugetlb::HugeTlbController,
     memory::MemController,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,12 +135,12 @@ mod sealed {
 
             if w {
                 match File::create(&path) {
-                    Err(e) => return Err(Error::with_cause(ErrorKind::WriteFailed, e)),
+                    Err(e) => return Err(Error::with_source(ErrorKind::WriteFailed, e)),
                     Ok(file) => return Ok(file),
                 }
             } else {
                 match File::open(&path) {
-                    Err(e) => return Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+                    Err(e) => return Err(Error::with_source(ErrorKind::ReadFailed, e)),
                     Ok(file) => return Ok(file),
                 }
             }
@@ -233,7 +233,7 @@ where
     fn add_task(&self, pid: &CgroupPid) -> Result<()> {
         self.open_path("tasks", true).and_then(|mut file| {
             file.write_all(pid.pid.to_string().as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use log::*;
-
 use std::fs::File;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -22,22 +20,23 @@ pub mod perf_event;
 pub mod pid;
 pub mod rdma;
 
-use crate::blkio::BlkIoController;
-use crate::cpu::CpuController;
-use crate::cpuacct::CpuAcctController;
-use crate::cpuset::CpuSetController;
-use crate::devices::DevicesController;
-use crate::error::*;
-use crate::freezer::FreezerController;
-use crate::hugetlb::HugeTlbController;
-use crate::memory::MemController;
-use crate::net_cls::NetClsController;
-use crate::net_prio::NetPrioController;
-use crate::perf_event::PerfEventController;
-use crate::pid::PidController;
-use crate::rdma::RdmaController;
-
 pub use crate::cgroup::Cgroup;
+use crate::{
+    blkio::BlkIoController,
+    cpu::CpuController,
+    cpuacct::CpuAcctController,
+    cpuset::CpuSetController,
+    devices::DevicesController,
+    error::{Error, ErrorKind, Result},
+    freezer::FreezerController,
+    hugetlb::HugeTlbController,
+    memory::MemController,
+    net_cls::NetClsController,
+    net_prio::NetPrioController,
+    perf_event::PerfEventController,
+    pid::PidController,
+    rdma::RdmaController,
+};
 
 /// Contains all the subsystems that are available in this crate.
 #[derive(Debug)]
@@ -214,7 +213,7 @@ where
 
         match ::std::fs::create_dir(self.get_path()) {
             Ok(_) => (),
-            Err(e) => warn!("error create_dir {:?}", e),
+            Err(e) => log::warn!("error create_dir {:?}", e),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
@@ -211,7 +211,7 @@ where
     fn create(&self) {
         self.verify_path().expect("path should be valid");
 
-        match ::std::fs::create_dir(self.get_path()) {
+        match fs::create_dir(self.get_path()) {
             Ok(_) => (),
             Err(e) => log::warn!("error create_dir {:?}", e),
         }
@@ -225,7 +225,7 @@ where
     /// Delete the controller.
     fn delete(&self) {
         if self.get_path().exists() {
-            let _ = ::std::fs::remove_dir(self.get_path());
+            let _ = fs::remove_dir(self.get_path());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,7 +271,7 @@ pub trait Hierarchy {
     fn root(&self) -> PathBuf;
 
     /// Return a handle to the root control group in the hierarchy.
-    fn root_control_group(&self) -> Cgroup;
+    fn root_control_group(&self) -> Cgroup<'_>;
 
     /// Checks whether a certain subsystem is supported in the hierarchy.
     ///

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -6,8 +6,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, MemoryResources, Resources, Subsystem,
@@ -109,7 +109,8 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
                     x.split("=").collect::<Vec<_>>()[1]
                         .parse::<u64>()
                         .unwrap_or(0)
-                }).collect()
+                })
+                .collect()
         },
         file_pages: file_line
             .split(|x| x == ' ' || x == '=')
@@ -123,7 +124,8 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
                     x.split("=").collect::<Vec<_>>()[1]
                         .parse::<u64>()
                         .unwrap_or(0)
-                }).collect()
+                })
+                .collect()
         },
         anon_pages: anon_line
             .split(|x| x == ' ' || x == '=')
@@ -137,7 +139,8 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
                     x.split("=").collect::<Vec<_>>()[1]
                         .parse::<u64>()
                         .unwrap_or(0)
-                }).collect()
+                })
+                .collect()
         },
         unevictable_pages: unevict_line
             .split(|x| x == ' ' || x == '=')
@@ -151,7 +154,8 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
                     x.split("=").collect::<Vec<_>>()[1]
                         .parse::<u64>()
                         .unwrap_or(0)
-                }).collect()
+                })
+                .collect()
         },
         hierarchical_total_pages: hier_total_line
             .split(|x| x == ' ' || x == '=')
@@ -165,7 +169,8 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
                     x.split("=").collect::<Vec<_>>()[1]
                         .parse::<u64>()
                         .unwrap_or(0)
-                }).collect()
+                })
+                .collect()
         },
         hierarchical_file_pages: hier_file_line
             .split(|x| x == ' ' || x == '=')
@@ -179,7 +184,8 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
                     x.split("=").collect::<Vec<_>>()[1]
                         .parse::<u64>()
                         .unwrap_or(0)
-                }).collect()
+                })
+                .collect()
         },
         hierarchical_anon_pages: hier_anon_line
             .split(|x| x == ' ' || x == '=')
@@ -193,7 +199,8 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
                     x.split("=").collect::<Vec<_>>()[1]
                         .parse::<u64>()
                         .unwrap_or(0)
-                }).collect()
+                })
+                .collect()
         },
         hierarchical_unevictable_pages: hier_unevict_line
             .split(|x| x == ' ' || x == '=')
@@ -207,7 +214,8 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
                     x.split("=").collect::<Vec<_>>()[1]
                         .parse::<u64>()
                         .unwrap_or(0)
-                }).collect()
+                })
+                .collect()
         },
     })
 }
@@ -564,11 +572,10 @@ impl MemController {
 
     /// Reset the fail counter
     pub fn reset_fail_count(&self) -> Result<()> {
-        self.open_path("memory.failcnt", true)
-            .and_then(|mut file| {
-                file.write_all("0".to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
-            })
+        self.open_path("memory.failcnt", true).and_then(|mut file| {
+            file.write_all("0".to_string().as_ref())
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 
     /// Reset the kernel memory fail counter
@@ -682,7 +689,10 @@ impl<'a> From<&'a Subsystem> for &'a MemController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -691,7 +691,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseFailed, e)),
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -573,7 +573,7 @@ impl MemController {
     pub fn reset_fail_count(&self) -> Result<()> {
         self.open_path("memory.failcnt", true).and_then(|mut file| {
             file.write_all("0".to_string().as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -582,7 +582,7 @@ impl MemController {
         self.open_path("memory.kmem.failcnt", true)
             .and_then(|mut file| {
                 file.write_all("0".to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -591,7 +591,7 @@ impl MemController {
         self.open_path("memory.kmem.tcp.failcnt", true)
             .and_then(|mut file| {
                 file.write_all("0".to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -600,7 +600,7 @@ impl MemController {
         self.open_path("memory.memsw.failcnt", true)
             .and_then(|mut file| {
                 file.write_all("0".to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -609,7 +609,7 @@ impl MemController {
         self.open_path("memory.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -618,7 +618,7 @@ impl MemController {
         self.open_path("memory.kmem.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -627,7 +627,7 @@ impl MemController {
         self.open_path("memory.memsw.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -636,7 +636,7 @@ impl MemController {
         self.open_path("memory.kmem.tcp.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -648,7 +648,7 @@ impl MemController {
         self.open_path("memory.soft_limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -660,7 +660,7 @@ impl MemController {
         self.open_path("memory.swappiness", true)
             .and_then(|mut file| {
                 file.write_all(swp.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 }
@@ -691,8 +691,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -700,7 +700,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -2,13 +2,12 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/memory.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt)
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, MemoryResources, Resources, Subsystem,
 };
@@ -574,7 +573,7 @@ impl MemController {
     pub fn reset_fail_count(&self) -> Result<()> {
         self.open_path("memory.failcnt", true).and_then(|mut file| {
             file.write_all("0".to_string().as_ref())
-                .map_err(|e| Error::with_cause(WriteFailed, e))
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })
     }
 
@@ -583,7 +582,7 @@ impl MemController {
         self.open_path("memory.kmem.failcnt", true)
             .and_then(|mut file| {
                 file.write_all("0".to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -592,7 +591,7 @@ impl MemController {
         self.open_path("memory.kmem.tcp.failcnt", true)
             .and_then(|mut file| {
                 file.write_all("0".to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -601,7 +600,7 @@ impl MemController {
         self.open_path("memory.memsw.failcnt", true)
             .and_then(|mut file| {
                 file.write_all("0".to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -610,7 +609,7 @@ impl MemController {
         self.open_path("memory.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -619,7 +618,7 @@ impl MemController {
         self.open_path("memory.kmem.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -628,7 +627,7 @@ impl MemController {
         self.open_path("memory.memsw.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -637,7 +636,7 @@ impl MemController {
         self.open_path("memory.kmem.tcp.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -649,7 +648,7 @@ impl MemController {
         self.open_path("memory.soft_limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 
@@ -661,7 +660,7 @@ impl MemController {
         self.open_path("memory.swappiness", true)
             .and_then(|mut file| {
                 file.write_all(swp.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 }
@@ -692,8 +691,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -701,7 +700,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -77,7 +77,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseFailed, e)),
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -6,12 +6,11 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources,
-    Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `net_cls` subsystem of a Cgroup.
@@ -76,7 +75,10 @@ impl<'a> From<&'a Subsystem> for &'a NetClsController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -97,7 +99,8 @@ impl NetClsController {
         self.open_path("net_cls.classid", true)
             .and_then(|mut file| {
                 let s = format!("{:#08X}", class);
-                file.write_all(s.as_ref()).map_err(|e| Error::with_cause(WriteFailed, e))
+                file.write_all(s.as_ref())
+                    .map_err(|e| Error::with_cause(WriteFailed, e))
             })
     }
 

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -2,13 +2,12 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/net_cls.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/net_cls.txt)
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources, Subsystem,
 };
@@ -45,7 +44,7 @@ impl ControllerInternal for NetClsController {
         if res.update_values {
             let _ = self.set_class(res.class_id);
             if self.get_class()? != res.class_id {
-                return Err(Error::new(Other));
+                return Err(Error::new(ErrorKind::Other));
             }
         }
         return Ok(());
@@ -78,8 +77,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -100,7 +99,7 @@ impl NetClsController {
             .and_then(|mut file| {
                 let s = format!("{:#08X}", class);
                 file.write_all(s.as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
             })
     }
 

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -77,8 +77,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -99,7 +99,7 @@ impl NetClsController {
             .and_then(|mut file| {
                 let s = format!("{:#08X}", class);
                 file.write_all(s.as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -44,7 +44,7 @@ impl ControllerInternal for NetClsController {
         if res.update_values {
             let _ = self.set_class(res.class_id);
             if self.get_class()? != res.class_id {
-                return Err(Error::new(ErrorKind::Other));
+                return Err(Error::new(ErrorKind::ApplyFailed));
             }
         }
         return Ok(());

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -78,8 +78,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -121,7 +121,7 @@ impl NetPrioController {
                             let ifname = ifname.unwrap();
                             let ifprio = ifprio.unwrap().trim().parse();
                             match ifprio {
-                                Err(e) => Err(Error::with_cause(ErrorKind::ParseError, e)),
+                                Err(e) => Err(Error::with_source(ErrorKind::ParseError, e)),
                                 Ok(_) => {
                                     acc.insert(ifname.to_string(), ifprio.unwrap());
                                     Ok(acc)
@@ -138,7 +138,7 @@ impl NetPrioController {
         self.open_path("net_prio.ifpriomap", true)
             .and_then(|mut file| {
                 file.write_all(format!("{} {}", eif, prio).as_ref())
-                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                    .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
             })
     }
 }

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -78,7 +78,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseFailed, e)),
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
@@ -116,12 +116,12 @@ impl NetPrioController {
                         let ifname = sp.nth(0);
                         let ifprio = sp.nth(1);
                         if ifname.is_none() || ifprio.is_none() {
-                            Err(Error::new(ErrorKind::ParseError))
+                            Err(Error::new(ErrorKind::ParseFailed))
                         } else {
                             let ifname = ifname.unwrap();
                             let ifprio = ifprio.unwrap().trim().parse();
                             match ifprio {
-                                Err(e) => Err(Error::with_source(ErrorKind::ParseError, e)),
+                                Err(e) => Err(Error::with_source(ErrorKind::ParseFailed, e)),
                                 Ok(_) => {
                                     acc.insert(ifname.to_string(), ifprio.unwrap());
                                     Ok(acc)

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -7,12 +7,11 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources,
-    Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `net_prio` subsystem of a Cgroup.
@@ -77,7 +76,10 @@ impl<'a> From<&'a Subsystem> for &'a NetPrioController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }

--- a/src/perf_event.rs
+++ b/src/perf_event.rs
@@ -2,10 +2,10 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [tools/perf/Documentation/perf-record.txt](https://raw.githubusercontent.com/torvalds/linux/master/tools/perf/Documentation/perf-record.txt)
+
 use std::path::PathBuf;
 
-use crate::error::*;
-
+use crate::error::Result;
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
 /// A controller that allows controlling the `perf_event` subsystem of a Cgroup.

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -2,13 +2,12 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroups-v1/pids.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt)
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, PidResources, Resources, Subsystem,
 };
@@ -62,7 +61,7 @@ impl ControllerInternal for PidController {
             if self.get_pid_max()? == pidres.maximum_number_of_processes {
                 return Ok(());
             } else {
-                return Err(Error::new(Other));
+                return Err(Error::new(ErrorKind::Other));
             }
         }
 
@@ -102,8 +101,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -127,11 +126,11 @@ impl PidController {
                 Ok(_) => match string.split_whitespace().nth(1) {
                     Some(elem) => match elem.parse() {
                         Ok(val) => Ok(val),
-                        Err(e) => Err(Error::with_cause(ParseError, e)),
+                        Err(e) => Err(Error::with_cause(ErrorKind::ParseError, e)),
                     },
-                    None => Err(Error::new(ParseError)),
+                    None => Err(Error::new(ErrorKind::ParseError)),
                 },
-                Err(e) => Err(Error::with_cause(ReadFailed, e)),
+                Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
             }
         })
     }
@@ -154,11 +153,11 @@ impl PidController {
                     } else {
                         match string.trim().parse() {
                             Ok(val) => Ok(PidMax::Value(val)),
-                            Err(e) => Err(Error::with_cause(ParseError, e)),
+                            Err(e) => Err(Error::with_cause(ErrorKind::ParseError, e)),
                         }
                     }
                 }
-                Err(e) => Err(Error::with_cause(ReadFailed, e)),
+                Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
             }
         })
     }
@@ -176,7 +175,7 @@ impl PidController {
             };
             match file.write_all(string_to_write.as_ref()) {
                 Ok(_) => Ok(()),
-                Err(e) => Err(Error::with_cause(WriteFailed, e)),
+                Err(e) => Err(Error::with_cause(ErrorKind::WriteFailed, e)),
             }
         })
     }

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -6,8 +6,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, PidResources, Resources, Subsystem,
@@ -99,7 +99,10 @@ impl<'a> From<&'a Subsystem> for &'a PidController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -145,14 +148,16 @@ impl PidController {
             let mut string = String::new();
             let res = file.read_to_string(&mut string);
             match res {
-                Ok(_) => if string.trim() == "max" {
-                    Ok(PidMax::Max)
-                } else {
-                    match string.trim().parse() {
-                        Ok(val) => Ok(PidMax::Value(val)),
-                        Err(e) => Err(Error::with_cause(ParseError, e)),
+                Ok(_) => {
+                    if string.trim() == "max" {
+                        Ok(PidMax::Max)
+                    } else {
+                        match string.trim().parse() {
+                            Ok(val) => Ok(PidMax::Value(val)),
+                            Err(e) => Err(Error::with_cause(ParseError, e)),
+                        }
                     }
-                },
+                }
                 Err(e) => Err(Error::with_cause(ReadFailed, e)),
             }
         })

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -101,8 +101,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_cause(ErrorKind::ParseError, e)),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -126,11 +126,11 @@ impl PidController {
                 Ok(_) => match string.split_whitespace().nth(1) {
                     Some(elem) => match elem.parse() {
                         Ok(val) => Ok(val),
-                        Err(e) => Err(Error::with_cause(ErrorKind::ParseError, e)),
+                        Err(e) => Err(Error::with_source(ErrorKind::ParseError, e)),
                     },
                     None => Err(Error::new(ErrorKind::ParseError)),
                 },
-                Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+                Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
             }
         })
     }
@@ -153,11 +153,11 @@ impl PidController {
                     } else {
                         match string.trim().parse() {
                             Ok(val) => Ok(PidMax::Value(val)),
-                            Err(e) => Err(Error::with_cause(ErrorKind::ParseError, e)),
+                            Err(e) => Err(Error::with_source(ErrorKind::ParseError, e)),
                         }
                     }
                 }
-                Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+                Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
             }
         })
     }
@@ -175,7 +175,7 @@ impl PidController {
             };
             match file.write_all(string_to_write.as_ref()) {
                 Ok(_) => Ok(()),
-                Err(e) => Err(Error::with_cause(ErrorKind::WriteFailed, e)),
+                Err(e) => Err(Error::with_source(ErrorKind::WriteFailed, e)),
             }
         })
     }

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -61,7 +61,7 @@ impl ControllerInternal for PidController {
             if self.get_pid_max()? == pidres.maximum_number_of_processes {
                 return Ok(());
             } else {
-                return Err(Error::new(ErrorKind::Other));
+                return Err(Error::new(ErrorKind::ApplyFailed));
             }
         }
 

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -101,7 +101,7 @@ fn read_u64_from(mut file: File) -> Result<u64> {
         Ok(_) => string
             .trim()
             .parse()
-            .map_err(|e| Error::with_source(ErrorKind::ParseError, e)),
+            .map_err(|e| Error::with_source(ErrorKind::ParseFailed, e)),
         Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
@@ -126,9 +126,9 @@ impl PidController {
                 Ok(_) => match string.split_whitespace().nth(1) {
                     Some(elem) => match elem.parse() {
                         Ok(val) => Ok(val),
-                        Err(e) => Err(Error::with_source(ErrorKind::ParseError, e)),
+                        Err(e) => Err(Error::with_source(ErrorKind::ParseFailed, e)),
                     },
-                    None => Err(Error::new(ErrorKind::ParseError)),
+                    None => Err(Error::new(ErrorKind::ParseFailed)),
                 },
                 Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
             }
@@ -153,7 +153,7 @@ impl PidController {
                     } else {
                         match string.trim().parse() {
                             Ok(val) => Ok(PidMax::Value(val)),
-                            Err(e) => Err(Error::with_source(ErrorKind::ParseError, e)),
+                            Err(e) => Err(Error::with_source(ErrorKind::ParseFailed, e)),
                         }
                     }
                 }

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -6,8 +6,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -2,13 +2,12 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/rdma.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/rdma.txt)
+
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
-use crate::error::*;
-
+use crate::error::{Error, ErrorKind, Result};
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
 /// A controller that allows controlling the `rdma` subsystem of a Cgroup.
@@ -64,7 +63,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -89,7 +88,7 @@ impl RdmaController {
     pub fn set_max(&self, max: &str) -> Result<()> {
         self.open_path("rdma.max", true).and_then(|mut file| {
             file.write_all(max.as_ref())
-                .map_err(|e| Error::with_cause(WriteFailed, e))
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })
     }
 }

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -63,7 +63,7 @@ fn read_string_from(mut file: File) -> Result<String> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ErrorKind::ReadFailed, e)),
+        Err(e) => Err(Error::with_source(ErrorKind::ReadFailed, e)),
     }
 }
 
@@ -88,7 +88,7 @@ impl RdmaController {
     pub fn set_max(&self, max: &str) -> Result<()> {
         self.open_path("rdma.max", true).and_then(|mut file| {
             file.write_all(max.as_ref())
-                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+                .map_err(|e| Error::with_source(ErrorKind::WriteFailed, e))
         })
     }
 }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -1,21 +1,21 @@
 //! Some simple tests covering the builder pattern for control groups.
-use cgroups::*;
-use cgroups::cpu::*;
-use cgroups::devices::*;
-use cgroups::pid::*;
-use cgroups::memory::*;
-use cgroups::net_cls::*;
-use cgroups::hugetlb::*;
 use cgroups::blkio::*;
 use cgroups::cgroup_builder::*;
+use cgroups::cpu::*;
+use cgroups::devices::*;
+use cgroups::hugetlb::*;
+use cgroups::memory::*;
+use cgroups::net_cls::*;
+use cgroups::pid::*;
+use cgroups::*;
 
 #[test]
 pub fn test_cpu_res_build() {
     let v1 = crate::hierarchies::V1::new();
     let cg: Cgroup = CgroupBuilder::new("test_cpu_res_build", &v1)
         .cpu()
-            .shares(85)
-            .done()
+        .shares(85)
+        .done()
         .build();
 
     {
@@ -32,10 +32,10 @@ pub fn test_memory_res_build() {
     let v1 = crate::hierarchies::V1::new();
     let cg: Cgroup = CgroupBuilder::new("test_memory_res_build", &v1)
         .memory()
-            .kernel_memory_limit(128 * 1024 * 1024)
-            .swappiness(70)
-            .memory_hard_limit(1024 * 1024 * 1024)
-            .done()
+        .kernel_memory_limit(128 * 1024 * 1024)
+        .swappiness(70)
+        .memory_hard_limit(1024 * 1024 * 1024)
+        .done()
         .build();
 
     {
@@ -53,8 +53,8 @@ pub fn test_pid_res_build() {
     let v1 = crate::hierarchies::V1::new();
     let cg: Cgroup = CgroupBuilder::new("test_pid_res_build", &v1)
         .pid()
-            .maximum_number_of_processes(PidMax::Value(123))
-            .done()
+        .maximum_number_of_processes(PidMax::Value(123))
+        .done()
         .build();
 
     {
@@ -72,23 +72,23 @@ pub fn test_devices_res_build() {
     let v1 = crate::hierarchies::V1::new();
     let cg: Cgroup = CgroupBuilder::new("test_devices_res_build", &v1)
         .devices()
-            .device(1, 6, DeviceType::Char, true,
-                    vec![DevicePermissions::Read])
-            .done()
+        .device(1, 6, DeviceType::Char, true, vec![DevicePermissions::Read])
+        .done()
         .build();
 
     {
         let c: &DevicesController = cg.controller_of().unwrap();
         assert!(c.allowed_devices().is_ok());
-        assert_eq!(c.allowed_devices().unwrap(), vec![
-                   DeviceResource {
-                       allow: true,
-                       devtype: DeviceType::Char,
-                       major: 1,
-                       minor: 6,
-                       access: vec![DevicePermissions::Read],
-                   }
-        ]);
+        assert_eq!(
+            c.allowed_devices().unwrap(),
+            vec![DeviceResource {
+                allow: true,
+                devtype: DeviceType::Char,
+                major: 1,
+                minor: 6,
+                access: vec![DevicePermissions::Read],
+            }]
+        );
     }
     cg.delete();
 }
@@ -98,8 +98,8 @@ pub fn test_network_res_build() {
     let v1 = crate::hierarchies::V1::new();
     let cg: Cgroup = CgroupBuilder::new("test_network_res_build", &v1)
         .network()
-            .class_id(1337)
-            .done()
+        .class_id(1337)
+        .done()
         .build();
 
     {
@@ -115,14 +115,17 @@ pub fn test_hugepages_res_build() {
     let v1 = crate::hierarchies::V1::new();
     let cg: Cgroup = CgroupBuilder::new("test_hugepages_res_build", &v1)
         .hugepages()
-            .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
-            .done()
+        .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
+        .done()
         .build();
 
     {
         let c: &HugeTlbController = cg.controller_of().unwrap();
         assert!(c.limit_in_bytes(&"2MB".to_string()).is_ok());
-        assert_eq!(c.limit_in_bytes(&"2MB".to_string()).unwrap(), 4 * 2 * 1024 * 1024);
+        assert_eq!(
+            c.limit_in_bytes(&"2MB".to_string()).unwrap(),
+            4 * 2 * 1024 * 1024
+        );
     }
     cg.delete();
 }
@@ -132,8 +135,8 @@ pub fn test_blkio_res_build() {
     let v1 = crate::hierarchies::V1::new();
     let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build", &v1)
         .blkio()
-            .weight(100)
-            .done()
+        .weight(100)
+        .done()
         .build();
 
     {

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -1,17 +1,20 @@
 //! Some simple tests covering the builder pattern for control groups.
-use cgroups::blkio::*;
-use cgroups::cgroup_builder::*;
-use cgroups::cpu::*;
-use cgroups::devices::*;
-use cgroups::hugetlb::*;
-use cgroups::memory::*;
-use cgroups::net_cls::*;
-use cgroups::pid::*;
-use cgroups::*;
+
+use cgroups::{
+    blkio::BlkIoController,
+    cgroup_builder::CgroupBuilder,
+    cpu::CpuController,
+    devices::{DevicePermissions, DeviceType, DevicesController},
+    hugetlb::HugeTlbController,
+    memory::MemController,
+    net_cls::NetClsController,
+    pid::{PidController, PidMax},
+    Cgroup, DeviceResource,
+};
 
 #[test]
 pub fn test_cpu_res_build() {
-    let v1 = crate::hierarchies::V1::new();
+    let v1 = cgroups::hierarchies::V1::new();
     let cg: Cgroup<'_> = CgroupBuilder::new("test_cpu_res_build", &v1)
         .cpu()
         .shares(85)
@@ -29,7 +32,7 @@ pub fn test_cpu_res_build() {
 
 #[test]
 pub fn test_memory_res_build() {
-    let v1 = crate::hierarchies::V1::new();
+    let v1 = cgroups::hierarchies::V1::new();
     let cg: Cgroup<'_> = CgroupBuilder::new("test_memory_res_build", &v1)
         .memory()
         .kernel_memory_limit(128 * 1024 * 1024)
@@ -50,7 +53,7 @@ pub fn test_memory_res_build() {
 
 #[test]
 pub fn test_pid_res_build() {
-    let v1 = crate::hierarchies::V1::new();
+    let v1 = cgroups::hierarchies::V1::new();
     let cg: Cgroup<'_> = CgroupBuilder::new("test_pid_res_build", &v1)
         .pid()
         .maximum_number_of_processes(PidMax::Value(123))
@@ -69,7 +72,7 @@ pub fn test_pid_res_build() {
 #[test]
 #[ignore] // ignore this test for now, not sure why my kernel doesn't like it
 pub fn test_devices_res_build() {
-    let v1 = crate::hierarchies::V1::new();
+    let v1 = cgroups::hierarchies::V1::new();
     let cg: Cgroup<'_> = CgroupBuilder::new("test_devices_res_build", &v1)
         .devices()
         .device(1, 6, DeviceType::Char, true, vec![DevicePermissions::Read])
@@ -95,7 +98,7 @@ pub fn test_devices_res_build() {
 
 #[test]
 pub fn test_network_res_build() {
-    let v1 = crate::hierarchies::V1::new();
+    let v1 = cgroups::hierarchies::V1::new();
     let cg: Cgroup<'_> = CgroupBuilder::new("test_network_res_build", &v1)
         .network()
         .class_id(1337)
@@ -112,7 +115,7 @@ pub fn test_network_res_build() {
 
 #[test]
 pub fn test_hugepages_res_build() {
-    let v1 = crate::hierarchies::V1::new();
+    let v1 = cgroups::hierarchies::V1::new();
     let cg: Cgroup<'_> = CgroupBuilder::new("test_hugepages_res_build", &v1)
         .hugepages()
         .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
@@ -132,7 +135,7 @@ pub fn test_hugepages_res_build() {
 
 #[test]
 pub fn test_blkio_res_build() {
-    let v1 = crate::hierarchies::V1::new();
+    let v1 = cgroups::hierarchies::V1::new();
     let cg: Cgroup<'_> = CgroupBuilder::new("test_blkio_res_build", &v1)
         .blkio()
         .weight(100)

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -12,7 +12,7 @@ use cgroups::*;
 #[test]
 pub fn test_cpu_res_build() {
     let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_cpu_res_build", &v1)
+    let cg: Cgroup<'_> = CgroupBuilder::new("test_cpu_res_build", &v1)
         .cpu()
         .shares(85)
         .done()
@@ -30,7 +30,7 @@ pub fn test_cpu_res_build() {
 #[test]
 pub fn test_memory_res_build() {
     let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_memory_res_build", &v1)
+    let cg: Cgroup<'_> = CgroupBuilder::new("test_memory_res_build", &v1)
         .memory()
         .kernel_memory_limit(128 * 1024 * 1024)
         .swappiness(70)
@@ -51,7 +51,7 @@ pub fn test_memory_res_build() {
 #[test]
 pub fn test_pid_res_build() {
     let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_pid_res_build", &v1)
+    let cg: Cgroup<'_> = CgroupBuilder::new("test_pid_res_build", &v1)
         .pid()
         .maximum_number_of_processes(PidMax::Value(123))
         .done()
@@ -70,7 +70,7 @@ pub fn test_pid_res_build() {
 #[ignore] // ignore this test for now, not sure why my kernel doesn't like it
 pub fn test_devices_res_build() {
     let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_devices_res_build", &v1)
+    let cg: Cgroup<'_> = CgroupBuilder::new("test_devices_res_build", &v1)
         .devices()
         .device(1, 6, DeviceType::Char, true, vec![DevicePermissions::Read])
         .done()
@@ -96,7 +96,7 @@ pub fn test_devices_res_build() {
 #[test]
 pub fn test_network_res_build() {
     let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_network_res_build", &v1)
+    let cg: Cgroup<'_> = CgroupBuilder::new("test_network_res_build", &v1)
         .network()
         .class_id(1337)
         .done()
@@ -113,7 +113,7 @@ pub fn test_network_res_build() {
 #[test]
 pub fn test_hugepages_res_build() {
     let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_hugepages_res_build", &v1)
+    let cg: Cgroup<'_> = CgroupBuilder::new("test_hugepages_res_build", &v1)
         .hugepages()
         .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
         .done()
@@ -133,7 +133,7 @@ pub fn test_hugepages_res_build() {
 #[test]
 pub fn test_blkio_res_build() {
     let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build", &v1)
+    let cg: Cgroup<'_> = CgroupBuilder::new("test_blkio_res_build", &v1)
         .blkio()
         .weight(100)
         .done()

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -1,4 +1,5 @@
 //! Simple unit tests about the control groups system.
+
 use cgroups::{Cgroup, CgroupPid};
 
 #[test]

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -1,14 +1,11 @@
 //! Integration tests about the pids subsystem
 use cgroups::pid::{PidController, PidMax};
-use cgroups::Controller;
-use cgroups::{Cgroup, CgroupPid, PidResources, Resources};
+use cgroups::{Cgroup, Controller};
 
 use nix::sys::wait::{waitpid, WaitStatus};
-use nix::unistd::{fork, ForkResult, Pid};
+use nix::unistd::{fork, ForkResult};
 
 use libc::pid_t;
-
-use std::thread;
 
 #[test]
 fn create_and_delete_cgroup() {

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -1,11 +1,11 @@
 //! Integration tests about the pids subsystem
-use cgroups::pid::{PidController, PidMax};
-use cgroups::{Cgroup, Controller};
 
+use libc::pid_t;
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::{fork, ForkResult};
 
-use libc::pid_t;
+use cgroups::pid::{PidController, PidMax};
+use cgroups::{Cgroup, Controller};
 
 #[test]
 fn create_and_delete_cgroup() {

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -1,4 +1,5 @@
 //! Integration test about setting resources using `apply()`
+
 use cgroups::pid::{PidController, PidMax};
 use cgroups::{Cgroup, PidResources, Resources};
 


### PR DESCRIPTION
*This PR is intended to be merged after #8 is merged.*

This PR modifies `ErrorKind` and `Error`.
- `ErrorKind`'s variants now have more consistent names.
- `ErrorKind` originally had `Other` variant. This was used only when a cgroup operation cannot be applied correctly. So this PR renames it to `ApplyFailed`.
- `Error` now implements [`std::error::Error::source()`](https://doc.rust-lang.org/std/error/trait.Error.html#method.source) instead of deprecated `cause()`.

This PR also re-exports `error::{ErrorKind, Error, Result}` for convenience.