### PR TITLE
Shrink unsafe blocks

### DIFF
--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -311,15 +311,15 @@ impl ControllIdentifier for BlkIoController {
 
 impl<'a> From<&'a Subsystem> for &'a BlkIoController {
     fn from(sub: &'a Subsystem) -> &'a BlkIoController {
-        unsafe {
+        
             match sub {
                 Subsystem::BlkIo(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -87,15 +87,15 @@ impl ControllIdentifier for CpuController {
 
 impl<'a> From<&'a Subsystem> for &'a CpuController {
     fn from(sub: &'a Subsystem) -> &'a CpuController {
-        unsafe {
+        
             match sub {
                 Subsystem::Cpu(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -114,15 +114,15 @@ impl ControllIdentifier for CpuSetController {
 
 impl<'a> From<&'a Subsystem> for &'a CpuSetController {
     fn from(sub: &'a Subsystem) -> &'a CpuSetController {
-        unsafe {
+        
             match sub {
                 Subsystem::CpuSet(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -173,15 +173,15 @@ impl ControllIdentifier for DevicesController {
 
 impl<'a> From<&'a Subsystem> for &'a DevicesController {
     fn from(sub: &'a Subsystem) -> &'a DevicesController {
-        unsafe {
+        
             match sub {
                 Subsystem::Devices(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -61,15 +61,15 @@ impl ControllIdentifier for FreezerController {
 
 impl<'a> From<&'a Subsystem> for &'a FreezerController {
     fn from(sub: &'a Subsystem) -> &'a FreezerController {
-        unsafe {
+        
             match sub {
                 Subsystem::Freezer(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -62,15 +62,15 @@ impl ControllIdentifier for HugeTlbController {
 
 impl<'a> From<&'a Subsystem> for &'a HugeTlbController {
     fn from(sub: &'a Subsystem) -> &'a HugeTlbController {
-        unsafe {
+        
             match sub {
                 Subsystem::HugeTlb(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -667,15 +667,15 @@ impl ControllIdentifier for MemController {
 
 impl<'a> From<&'a Subsystem> for &'a MemController {
     fn from(sub: &'a Subsystem) -> &'a MemController {
-        unsafe {
+        
             match sub {
                 Subsystem::Mem(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -61,15 +61,15 @@ impl ControllIdentifier for NetClsController {
 
 impl<'a> From<&'a Subsystem> for &'a NetClsController {
     fn from(sub: &'a Subsystem) -> &'a NetClsController {
-        unsafe {
+        
             match sub {
                 Subsystem::NetCls(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/perf_event.rs
+++ b/src/perf_event.rs
@@ -45,15 +45,15 @@ impl ControllIdentifier for PerfEventController {
 
 impl<'a> From<&'a Subsystem> for &'a PerfEventController {
     fn from(sub: &'a Subsystem) -> &'a PerfEventController {
-        unsafe {
+        
             match sub {
                 Subsystem::PerfEvent(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -84,15 +84,15 @@ impl ControllIdentifier for PidController {
 
 impl<'a> From<&'a Subsystem> for &'a PidController {
     fn from(sub: &'a Subsystem) -> &'a PidController {
-        unsafe {
+        
             match sub {
                 Subsystem::Pid(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -48,15 +48,15 @@ impl ControllIdentifier for RdmaController {
 
 impl<'a> From<&'a Subsystem> for &'a RdmaController {
     fn from(sub: &'a Subsystem) -> &'a RdmaController {
-        unsafe {
+        
             match sub {
                 Subsystem::Rdma(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    unsafe { ::std::mem::uninitialized() }
                 }
             }
-        }
+        
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 


Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 